### PR TITLE
Remove annoying "command"

### DIFF
--- a/src/main/java/me/vilsol/skypebot/modules/General.java
+++ b/src/main/java/me/vilsol/skypebot/modules/General.java
@@ -337,11 +337,6 @@ public class General implements Module {
         }
     }
 
-    @Command(name = "night", exact = false, command = false)
-    public static void cmdNight(ChatMessage chat){
-        R.s("Pussy");
-    }
-
     @Command(name = "sql")
     public static void cmdSQL(ChatMessage chat, String query) throws SQLException{
         if(SkypeBot.getInstance().getDatabase() == null){


### PR DESCRIPTION
This is just plain annoying, as there are many and countless times where this is triggered, and "night" was not being referenced in a going to sleep use.
